### PR TITLE
Fix api deprecation

### DIFF
--- a/core.py
+++ b/core.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QPixmap, QRegion, QImage
 from PySide6.QtWidgets import QApplication, QWidget
 
 
-def _scaledSize(r: QRect, scale: int) -> QSize:
+def _scaledSize(r: QRect, scale: float) -> QSize:
     """
     Get the scaled size of a QRect.
 

--- a/core.py
+++ b/core.py
@@ -1,4 +1,4 @@
-from binaryninjaui import DockHandler
+from binaryninjaui import UIContext
 
 from PySide6.QtCore import QPoint, QRect, QSize
 from PySide6.QtGui import QPixmap, QRegion, QImage
@@ -61,10 +61,10 @@ def renderActiveView(scale: float) -> QPixmap:
     :param scale: the DPI-scaling factor to render the image at
     """
 
-    dockHandler = DockHandler.getActiveDockHandler()
-    if viewFrame := dockHandler.getViewFrame():
+    uiContext = UIContext.activeContext()
+    if uiContext and (viewFrame := uiContext.getCurrentViewFrame()):
         if (view := viewFrame.getCurrentWidget()) is None:
-            raise ValueError("Could not find active view via dock handler.")
+            raise ValueError("Could not find active view via ui context.")
     elif activeWindow := QApplication.activeWindow():
         if (view := activeWindow.childAt(QPoint(150, 150))) is None:
             raise ValueError("Could not find active view via heuristics.")


### PR DESCRIPTION
DockHandler got removed in `4.3.6465-dev` (https://github.com/Vector35/binaryninja-api/issues/6189) so i updated it to use `UIContext` to get the current view frame